### PR TITLE
Devel

### DIFF
--- a/src/crtk_lib_cpp/include/crtk_lib_cpp/crtk_robot_state.h
+++ b/src/crtk_lib_cpp/include/crtk_lib_cpp/crtk_robot_state.h
@@ -1,5 +1,5 @@
 /* Raven 2 Control - Control software for the Raven II robot
- * Copyright (C) 2005-2018  Andrew Lewis, Yun-Hsuan Su, Blake Hannaford, 
+ * Copyright (C) 2005-2018  Andrew Lewis, Yun-Hsuan Su, Blake Hannaford,
  * and the University of Washington BioRobotics Laboratory
  *
  * This file is part of Raven 2 Control.
@@ -37,10 +37,10 @@
 #include <crtk_msgs/StringStamped.h>
 
 
-class CRTK_robot_state 
+class CRTK_robot_state
 {
  public:
-  
+
   // methods
   CRTK_robot_state();
   CRTK_robot_state(ros::NodeHandle n);
@@ -73,7 +73,7 @@ class CRTK_robot_state
   bool set_connected(bool);
 
   bool init_ros(ros::NodeHandle);
-  void crtk_state_cb(crtk_msgs::operating_state msg);
+  void operating_state_cb(crtk_msgs::operating_state msg);
   void crtk_command_pb(CRTK_robot_command);
 
   char state_char();

--- a/src/crtk_lib_cpp/src/crtk_robot_state.cpp
+++ b/src/crtk_lib_cpp/src/crtk_robot_state.cpp
@@ -1,5 +1,5 @@
 /* Raven 2 Control - Control software for the Raven II robot
- * Copyright (C) 2005-2018  Andrew Lewis, Yun-Hsuan Su, Blake Hannaford, 
+ * Copyright (C) 2005-2018  Andrew Lewis, Yun-Hsuan Su, Blake Hannaford,
  * and the University of Washington BioRobotics Laboratory
  *
  * This file is part of Raven 2 Control.
@@ -73,7 +73,7 @@ CRTK_robot_state::CRTK_robot_state(ros::NodeHandle n){
 bool CRTK_robot_state::init_ros(ros::NodeHandle n){
 
   pub = n.advertise<crtk_msgs::StringStamped>("state_command", 1);
-  sub = n.subscribe("crtk_state", 1, &CRTK_robot_state::crtk_state_cb,this);
+  sub = n.subscribe("operating_state", 1, &CRTK_robot_state::operating_state_cb,this);
 
   return true;
 }
@@ -84,7 +84,7 @@ bool CRTK_robot_state::init_ros(ros::NodeHandle n){
  *
  * @param[in]  msg   The message from ROS
  */
-void CRTK_robot_state::crtk_state_cb(crtk_msgs::operating_state msg){
+void CRTK_robot_state::operating_state_cb(crtk_msgs::operating_state msg){
 
   std::string state = msg.state;
 
@@ -127,7 +127,7 @@ void CRTK_robot_state::crtk_state_cb(crtk_msgs::operating_state msg){
  * @param[in]  command  The command
  */
 void CRTK_robot_state::crtk_command_pb(CRTK_robot_command command){
-  
+
   static int count = 0;
   static crtk_msgs::StringStamped msg_command;
 
@@ -135,38 +135,38 @@ void CRTK_robot_state::crtk_command_pb(CRTK_robot_command command){
   switch(command)
   {
     case CRTK_ENABLE:
-      msg_command.data = "enable";
-      ROS_INFO("Sent ENABLE: May need to press start button."); 
+      msg_command.string = "enable";
+      ROS_INFO("Sent ENABLE: May need to press start button.");
       break;
 
     case CRTK_DISABLE:
-      msg_command.data = "disable";
-      ROS_INFO("Sent DISABLE."); 
+      msg_command.string = "disable";
+      ROS_INFO("Sent DISABLE.");
       break;
 
     case CRTK_PAUSE:
-      msg_command.data = "pause";
-      ROS_INFO("Sent PAUSE."); 
+      msg_command.string = "pause";
+      ROS_INFO("Sent PAUSE.");
       break;
 
     case CRTK_RESUME:
-      msg_command.data = "resume";
-      ROS_INFO("Sent RESUME."); 
+      msg_command.string = "resume";
+      ROS_INFO("Sent RESUME.");
       break;
 
     case CRTK_UNHOME:
-      msg_command.data = "unhome";
-      ROS_INFO("Sent UNHOME."); 
+      msg_command.string = "unhome";
+      ROS_INFO("Sent UNHOME.");
       break;
 
     case CRTK_HOME:
-      msg_command.data = "home";
-      ROS_INFO("Sent HOME."); 
+      msg_command.string = "home";
+      ROS_INFO("Sent HOME.");
       break;
 
     default:
-      msg_command.data = "NULL";
-      ROS_INFO("Sent NULL."); 
+      msg_command.string = "NULL";
+      ROS_INFO("Sent NULL.");
       break;
   }
   msg_command.header.stamp = msg_command.header.stamp.now();
@@ -259,7 +259,7 @@ bool CRTK_robot_state::ready_logic(){
 bool CRTK_robot_state::set_disabled_state(){
   is_disabled   = 1;
   is_enabled    = 0;
-  is_paused     = 0;  
+  is_paused     = 0;
   is_fault      = 0;
 
   return 0;
@@ -275,7 +275,7 @@ bool CRTK_robot_state::set_disabled_state(){
 bool CRTK_robot_state::set_enabled_state(){
   is_disabled   = 0;
   is_enabled    = 1;
-  is_paused     = 0;  
+  is_paused     = 0;
   is_fault      = 0;
 
   return 0;
@@ -291,7 +291,7 @@ bool CRTK_robot_state::set_enabled_state(){
 bool CRTK_robot_state::set_paused_state(){
   is_disabled   = 0;
   is_enabled    = 0;
-  is_paused     = 1;  
+  is_paused     = 1;
   is_fault      = 0;
 
   return 0;
@@ -307,7 +307,7 @@ bool CRTK_robot_state::set_paused_state(){
 bool CRTK_robot_state::set_fault_state(){
   is_disabled   = 0;
   is_enabled    = 0;
-  is_paused     = 0;  
+  is_paused     = 0;
   is_fault      = 1;
 
   return 0;

--- a/src/crtk_test_state/src/state_tests.cpp
+++ b/src/crtk_test_state/src/state_tests.cpp
@@ -26,7 +26,7 @@ int state_testing(CRTK_robot_state robot_state, time_t current_time){
   static int current_test = 0;
   static int finished = 0;
   static int errors = 0;
-  
+
 
   int test_status;
   int num_of_tests = 8; //update when adding or removing tests
@@ -92,7 +92,7 @@ int state_testing(CRTK_robot_state robot_state, time_t current_time){
     case 3:
     {
         // VI-2.    {paused, p_up} + disable → {disabled / e-stop}
-        // VIII-2.    {disabled, homed} + unhome → {disabled, ~homed / e-stop} 
+        // VIII-2.    {disabled, homed} + unhome → {disabled, ~homed / e-stop}
         test_status = test_3(robot_state, current_time);
         if (test_status < 0) {
           errors += 1;
@@ -454,7 +454,7 @@ int test_2(CRTK_robot_state robot_state, time_t current_time){
 
 
 /**
- * @brief      The test function 3: VI-2.    {paused, p_up} + disable → {disabled / e-stop} 
+ * @brief      The test function 3: VI-2.    {paused, p_up} + disable → {disabled / e-stop}
  *                                  VIII-2.    {disabled, homed} + unhome → {disabled, ~homed / e-stop} (starting at case 8)
  *
  * @param[in]  robot_state   The robot state
@@ -612,7 +612,7 @@ int test_3(CRTK_robot_state robot_state, time_t current_time){
 
 
 /**
- * @brief      The test function 4: IV-1.    {enabled, homing} + pause → {disabled / e-stop} 
+ * @brief      The test function 4: IV-1.    {enabled, homing} + pause → {disabled / e-stop}
  *                                  VIII-1.  {disabled, ~homed} + unhome → {disabled, ~homed / e-stop}
  *
  * @param[in]  robot_state   The robot state
@@ -787,7 +787,7 @@ int test_4(CRTK_robot_state robot_state, time_t current_time){
 
 
 /**
- * @brief      The test function 5: III-1.    {enabled, homing} + disable → {disabled / e-stop} 
+ * @brief      The test function 5: III-1.    {enabled, homing} + disable → {disabled / e-stop}
  *                                  III-2.    {enabled, busy} + disable → {disabled / e-stop}
  *
  * @param[in]  robot_state   The robot state
@@ -816,7 +816,7 @@ int test_5(CRTK_robot_state robot_state, time_t current_time){
       getline(std::cin,start);
       if(start == ""){
         current_step ++;
-      } 
+      }
       break;
     }
     case 2:
@@ -919,7 +919,7 @@ int test_5(CRTK_robot_state robot_state, time_t current_time){
 
 
 /**
- * @brief      The test function 6: VIII-3.    {enabled, homing} + unhome → {disabled, ~homed / e-stop} 
+ * @brief      The test function 6: VIII-3.    {enabled, homing} + unhome → {disabled, ~homed / e-stop}
  *                                  VIII-4.    {enabled, busy} + unhome → {disabled, ~homed / e-stop}
  *
  * @param[in]  robot_state   The robot state

--- a/src/crtk_util_footkey/src/main.cpp
+++ b/src/crtk_util_footkey/src/main.cpp
@@ -1,5 +1,5 @@
 /* Raven 2 Control - Control software for the Raven II robot
- * Copyright (C) 2005-2018  Andrew Lewis, Yun-Hsuan Su, Blake Hannaford, 
+ * Copyright (C) 2005-2018  Andrew Lewis, Yun-Hsuan Su, Blake Hannaford,
  * and the University of Washington BioRobotics Laboratory
  *
  * This file is part of Raven 2 Control.
@@ -73,8 +73,8 @@ int main(int argc, char **argv)
 
   //start ros node
   ros::init(argc, argv, "crtk_util_footkey");
-  static ros::NodeHandle n; 
-  ros::Rate loop_rate(LOOP_RATE); 
+  static ros::NodeHandle n;
+  ros::Rate loop_rate(LOOP_RATE);
 
   ROS_INFO("!~~~~~~~~~~~~ Starting keyboard node ~~~~~~~~~~~");
   ROS_INFO("Press 'Z' or 'R' twice to do a barrel roll");
@@ -102,19 +102,19 @@ int main(int argc, char **argv)
 
 
 /**
- * @brief      checks terminal for 'e' or 'd' 
+ * @brief      checks terminal for 'e' or 'd'
  *
  * @return     -1 for pedal down (d)
  *              0 for null or unsupported entry
  *              1 for pedal up
- *        
+ *
  */
 int foot_pedal(){
   int key_in;
 
   key_in = getkey();
 
-  if(key_in == 'd') return -1; 
+  if(key_in == 'd') return -1;
   else if(key_in == 'e') return 1;
   else return 0;
 
@@ -133,14 +133,14 @@ int pub_foot(int foot){
 
   if(foot == 1){
     //pub pedal up
-    msg_command.data = "pause";
-    ROS_INFO("Sent pause.");  
+    msg_command.string = "pause";
+    ROS_INFO("Sent pause.");
   }
 
   else if(foot == -1){
     //pub pedal down
-    msg_command.data = "resume";
-    ROS_INFO("Sent resume.");  
+    msg_command.string = "resume";
+    ROS_INFO("Sent resume.");
 
   } else return 0;
 


### PR DESCRIPTION
Mostly two changes:
 * I renamed the data member "data" to "string" in the StringStamped message to match other ROS Stamped messages naming convention (also requires merge of devel branch in crtk-msgs)
 * I renamed crtk_state to operating_state.  Since this is part of crtk already, I feel that the crtk_ prefix is redundant